### PR TITLE
Issue / Migrate to Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Here, you will find information about how we govern our collective.
 
 - [Roles](./roles.md): Roles and how they are applied to our Discord server and
   GitHub organization
-- [Communication](./communication.md): Our communication preferences in Discord
-- [Work](./work.md): How we organize our work in GitHub and Discord.
+- [Communication](./communication.md): Our communication preferences in Matrix
+- [Work](./work.md): How we organize our work in GitHub and Matrix.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Here, you will find information about how we govern our collective.
 
-- [Roles](./roles.md): Roles and how they are applied to our Discord server and
+- [Roles](./roles.md): Roles and how they are applied to our Matrix space and
   GitHub organization
 - [Communication](./communication.md): Our communication preferences in Matrix
 - [Work](./work.md): How we organize our work in GitHub and Matrix.

--- a/communication.md
+++ b/communication.md
@@ -15,6 +15,9 @@ sharing within our collective. These rooms have video call enabled.
 >   have access to.
 > - All rooms are published using their names, e.g., `#office:mouseless.org`,
 >   `#baked:mouseless.org`, so you can mention them using hashtags across rooms.
+> - Room or space names may utilize an emoji as the initial character to have it
+>   in the room's avatar
+> - A room may have a custom icon where possible
 
 ## Public Space (`#public`)
 
@@ -58,6 +61,10 @@ You may leave any room at any time whenever you think that is obsolete.
 `@admin:mouseless.org` will always have access to idle rooms for archiving
 purposes. Once archived, rooms will be removed from space listing and will have
 no published names.
+
+## Migration from Discord
+
+We've used Discord from `2022` through `2024`, below are migration notes.
 
 > [!NOTE]
 >

--- a/communication.md
+++ b/communication.md
@@ -1,6 +1,6 @@
 # Communication
 
-We use Discord categories, text and voice channels for communication.
+We use Matrix spaces and rooms for communication.
 
 ## Root
 

--- a/communication.md
+++ b/communication.md
@@ -1,70 +1,75 @@
 # Communication
 
-We use Matrix spaces and rooms for communication.
+We use Matrix spaces and rooms for communication. We have our own home server at
+`mouseless.org`. To join please visit
+[#collective:mouseless.org](https://matrix.to/#/#collective:mouseless.org).
 
-## Root
+## Root Space (`#collective`)
 
-Office is the only channel at the root without a category. It is a member only
-private voice channel. This is where you join when you're actively working for
-the collective. This channel is restricted to use Push-to-Talk.
+At the root there are rooms to enable a public discussion and information
+sharing within our collective. These rooms have video call enabled.
 
-## Public Category
+> [!IMPORTANT]
+>
+> - All rooms are owned and governed by `@admin:mouseless.org` where all owners
+>   have access to.
+> - All rooms are published using their names, e.g., `#office:mouseless.org`,
+>   `#baked:mouseless.org`, so you can mention them using hashtags across rooms.
 
-This category is to enable a public discussion and information sharing within
-our collective. Anything under this category is read/write for a Contributor and
-above, but read-only for the rest.
+## Public Space (`#public`)
 
-- It is allowed to open various text and voice channels under this category
-- Voice channels under this category might restrict users to use Push-to-Talk
-  when needed
+This space contains only rooms for public repositories. It is open for anyone to
+join.
 
-## Meet Category
+Rooms under this space;
 
-Meet category is to allow organize meetings in physical and digital worlds.
+- Is not allowed to have video calls enabled
+- Is optional for non-active repositories
 
-Text channels under this category;
+## Private Space (`#private`)
 
+This space is for members-only, where rooms for private repositories are
+available. Non-repository rooms like `#office` also exists to allow general
+private discussions.
+
+> [!TIP]
+>
+> Each room has its own purpose explained under their room description in
+> Matrix.
+
+Rooms under this space;
+
+- Are members-only, and further restriction can be made
 - Can be created, updated and deleted according to the project management and
   communication needs
-- Are member only, and further restriction can be made according to functional
-  roles
+- Is optional for non-active repositories
+- Must have video calls enabled if they are for discussion (non-repository
+  room).
 
-Voice Channels under this category;
+### Administration Space (`#administration`)
 
-- Can be used with voice activity setting enabled in discord, but to avoid
-  overlapping talks number of users should be limited
-- Can be created, updated and deleted on demand
-- Are member only, and further restriction can be made according to functional
-  roles
+This space is empty in collective's home server, but anyone joins becomes a
+`Moderator` to allow to add your own administration rooms to have a private
+discussion regarding your clients and/or any other administrative purpose.
 
-## Administrate Category
+## Archiving a room
 
-This category is both a backlog and a communication category. It contains text
-channels such as `governance` and `work` as well as company channels to allow
-communication concerning administrative issues.
+You may leave any room at any time whenever you think that is obsolete.
+`@admin:mouseless.org` will always have access to idle rooms for archiving
+purposes. Once archived, rooms will be removed from space listing and will have
+no published names.
 
-- Repository text channels are subject to the rules explained in
-  [work](./work.md)
-- Company text channels are;
-  - Private text channels
-  - Accessible to owners and the only company representative
-  - Used to publish automatic progress report of members in company
-
-> :information_source:
+> [!NOTE]
 >
-> Note that all members don't have a direct administrative channel with the
-> owners. Each representative is expected to handle its own internal
-> administrative communication. This is to promote open communication for
-> non-admin subjects and to allow a more decentralized collective structure for
-> the future.
-
-## -Archive- Category
-
-Text channels are never deleted if they are once used actively. This category
-contains unused channels to keep the messages.
-
-Text channels under this category;
-
-- is only accessible by owners
-- is renamed to include its old category as a prefix, e.g., `apple` under
-  develop would be `develop-apple` when archived
+> - Each channel has an import message pinned to the top containing discord
+>   exports in html format
+> - Archived channels wasn't imported at all
+> - Some channels merged into one room
+>   - `meet/digitally` -> `#random`
+>   - `meet/physically` -> `#random`
+>   - `meet/lounge` -> `#random`
+>   - `meet/daily` -> `#office`
+>   - `digitally[private]` -> `#office`
+>   - `announcements` -> `#governance`
+>     - message archive is in `#office` since early usage contains private
+>       discussions

--- a/communication.md
+++ b/communication.md
@@ -61,22 +61,3 @@ You may leave any room at any time whenever you think that is obsolete.
 `@admin:mouseless.org` will always have access to idle rooms for archiving
 purposes. Once archived, rooms will be removed from space listing and will have
 no published names.
-
-## Migration from Discord
-
-We've used Discord from `2022` through `2024`, below are migration notes.
-
-> [!NOTE]
->
-> - Each channel has an import message pinned to the top containing discord
->   exports in html format
-> - Archived channels wasn't imported at all
-> - Some channels merged into one room
->   - `meet/digitally` -> `#random`
->   - `meet/physically` -> `#random`
->   - `meet/lounge` -> `#random`
->   - `meet/daily` -> `#office`
->   - `digitally[private]` -> `#office`
->   - `announcements` -> `#governance`
->     - message archive is in `#office` since early usage contains private
->       discussions

--- a/communication.md
+++ b/communication.md
@@ -19,7 +19,7 @@ sharing within our collective. These rooms have video call enabled.
 >   in the room's avatar
 > - A room may have a custom icon where possible
 
-## Public Space (`#public`)
+## Public Space
 
 This space contains only rooms for public repositories. It is open for anyone to
 join.
@@ -29,7 +29,7 @@ Rooms under this space;
 - Is not allowed to have video calls enabled
 - Is optional for non-active repositories
 
-## Private Space (`#private`)
+## Private Space
 
 This space is for members-only, where rooms for private repositories are
 available. Non-repository rooms like `#office` also exists to allow general
@@ -49,7 +49,7 @@ Rooms under this space;
 - Must have video calls enabled if they are for discussion (non-repository
   room).
 
-### Administration Space (`#administration`)
+### Administration Space
 
 This space is empty in collective's home server, but anyone joins becomes a
 `Moderator` to allow to add your own administration rooms to have a private

--- a/roles.md
+++ b/roles.md
@@ -16,9 +16,9 @@ collective.
 
 - **Owner**: Makes the final decisions and handles responsibilities not covered
   by current roles
-- **Member**: People with legal binding so that they get paid for what they do
-- **Contributor**: People with no legal binding but known personally within our
-  network who voluntarily contribute to public repositories
+- **Member**: People with legal binding
+- **Contributor**: People with no legal binding within our network who
+  voluntarily contribute to public repositories
 
 ## Rules to Follow
 

--- a/roles.md
+++ b/roles.md
@@ -24,11 +24,10 @@ collective.
 
 - A person may have zero or one legal status
 - A person may belong to multiple teams
-- Teams are configured as mentionable roles in Discord
 - An owner is set as owner within the GitHub organization
 - A member is added to GitHub organization
-- New roles can be created in a specific service (Discord, GitHub etc.) to
+- New roles can be created in a specific service (Matrix, GitHub etc.) to
   workaround restrictions of that service
-- Any permission in a specific service (Discord, GitHub etc.) is allowed to be
+- Any permission in a specific service (Matrix, GitHub etc.) is allowed to be
   given to any role by moderators of that service unless it has a direct
   conflict with this governance model

--- a/work.md
+++ b/work.md
@@ -49,5 +49,5 @@ access active works through the most recently rooms at the top.
 ## A Note on Project Management
 
 Our project management methodology is not yet documented. Until it is done,
-please take the latest works as an example and ask for help in a text channel
+please take the latest works as an example and ask for help in a chat room
 related to your work if you have any questions.

--- a/work.md
+++ b/work.md
@@ -9,11 +9,7 @@ Each backlog is a prioritized list of work items to be done.
 In GitHub, a backlog is represented by a single markdown file in the private
 `work` repository. Backlogs appear under the `01-todo` folder per company.
 
-In Discord,
-
-- Backlogs are represented by categories after communication categories
-- Categories should not have custom permission to be able to move the channels
-  from one category to another without a concern
+In Matrix, a backlog doesn't have any correspondance.
 
 ## Repository / Text Channel
 
@@ -29,28 +25,26 @@ We utilize git repositories to store;
 Most of the work we do has a corresponding repository, unless it is related to
 daily operations or routine tasks.
 
-In Discord, each repository is represented by a text channel with a webhook
-configured from GitHub to Discord.
+In Matrix, each repository is represented by a chat room.
 
-Private repositories have private text channels, and are accesible only to
-Members and above, whereas public repositories are accessible to anyone in the
-collective.
+Private repositories are under an invite only space named `🔒 private`, and are
+accesible only to Members and above, whereas public repositories are accessible
+to anyone in the collective via the public space named `🌐 public`.
 
-Write permissions for a public repository / text channel and read / write
-permissions for a private repository / text channel are given to the responsible
-teams only.
+Write permissions for a public repository and read / write permissions for a
+private repository are given to the responsible teams only. In Matrix, anybody
+can write to a room they join.
 
 ## Work Item / Pull Requests / Threads
 
 An active work item is placed under `02-in-progress` folder of the private
 `work` repository as a separate markdown file. If this work is under a
 repository, it has a corresponding pull request (PR) in GitHub and a
-corresponding thread in Discord. These PRs and threads are temporary places to
+corresponding thread in Matrix. These PRs and threads are temporary places to
 discuss the active work and closed as soon as it is done.
 
-We have an `Actively Working` category in Discord, to find active work threads
-easily. A text channel with an active thread is temporarily moved under this
-category by an Owner until the work is done.
+Matrix rooms can be sorted according to their activities, which makes it easy to
+access active works through the most recently rooms at the top.
 
 ## A Note on Project Management
 

--- a/work.md
+++ b/work.md
@@ -2,7 +2,7 @@
 
 We manage our work using various backlogs and repositories.
 
-## Backlog / Category
+## Backlog
 
 Each backlog is a prioritized list of work items to be done.
 
@@ -11,7 +11,7 @@ In GitHub, a backlog is represented by a single markdown file in the private
 
 In Matrix, a backlog doesn't have any correspondance.
 
-## Repository / Text Channel
+## Repository
 
 We utilize git repositories to store;
 


### PR DESCRIPTION
Migrate from Discord to Matrix

> [!IMPORTANT]
>
> - Each channel has an import message pinned to the top containing discord
>   exports in html format
> - Archived channels wasn't imported at all
> - Some channels merged into one room
>   - `meet/digitally` -> `#random`
>   - `meet/physically` -> `#random`
>   - `meet/lounge` -> `#random`
>   - `meet/daily` -> `#office`
>   - `digitally[private]` -> `#office`
>   - `announcements` -> `#governance`
>     - message archive is in `#office` since early usage contains private
>       discussions

## Tasks

- [x] research
  - [x] threads
  - [x] voice/video call
  - [x] space and subspaces
  - [x] voice/video rooms (in place for voice channels in discord)
- [x] matrix hosting
  - [x] poc using digitalocean
  - [x] gcbrains/website deploy using sftp to droplet
  - [x] move poc server from online.gcbrains.com to final gcbrains.com
  - [x] migrate gcbrains slack -> gcbrains matrix
  - [x] create new matrix instance (mouseless.org)
- [x] exports
  - [x] discord
  - [x] slack (temp mouseless + gcbrains)
- [x] user invitations
  - [x] alpha
  - [x] beta
- [x] organize mouseless space
- [x] documentation
- [x] import messages
  - pin exports to room's by admin
