### PR TITLE
Issue / Matrix Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Here, you will find information about how we govern our collective.
 - [Roles](./roles.md): Roles and how they are applied to our Matrix space and
   GitHub organization
 - [Communication](./communication.md): Our communication preferences in Matrix
-- [Work](./work.md): How we organize our work in GitHub and Matrix.
+- [Work](./work.md): How we organize our work in GitHub and Matrix

--- a/communication.md
+++ b/communication.md
@@ -55,6 +55,9 @@ This space is empty in collective's home server, but anyone joins becomes a
 `Moderator` to allow to add your own administration rooms to have a private
 discussion regarding your clients and/or any other administrative purpose.
 
+To be able to receive automated worklog reports, `@admin:mouseless.org` is
+required to be invited to the rooms under this space.
+
 ## Archiving a room
 
 You may leave any room at any time whenever you think that is obsolete.

--- a/roles.md
+++ b/roles.md
@@ -7,7 +7,7 @@ collective.
   public repositories
 - **Member**: People with legal binding who work for customer projects within
   the collective
-- **Owner**: Responsible for the things that are not, or cannot, delegated to
+- **Owner**: Responsible for the things that are not, or cannot be, delegated to
   members or contributors
 
 ## Rules to Follow

--- a/roles.md
+++ b/roles.md
@@ -7,10 +7,6 @@ collective.
 
 - **Coders**: People who professionally write code
 - **Governors**: People who make contributions to the governance model
-- **Lawyers**: People who provide legal advice, create, and review legal
-  contracts
-- **Marketers**: People who take initiative in marketing the collective and its
-  projects
 
 ## Legal Statuses
 

--- a/roles.md
+++ b/roles.md
@@ -3,25 +3,19 @@
 Roles define the authority and accountibility of individuals within our
 collective.
 
-## Teams
-
-- **Coders**: People who professionally write code
-- **Governors**: People who make contributions to the governance model
-
-## Legal Statuses
-
-- **Owner**: Makes the final decisions and handles responsibilities not covered
-  by current roles
-- **Member**: People with legal binding
-- **Contributor**: People with no legal binding within our network who
-  voluntarily contribute to public repositories
+- **Contributor**: People with no legal binding who voluntarily contribute to
+  public repositories
+- **Member**: People with legal binding who work for customer projects within
+  the collective
+- **Owner**: Responsible for the things that are not, or cannot, delegated to
+  members or contributors
 
 ## Rules to Follow
 
-- A person may have zero or one legal status
-- A person may belong to multiple teams
+- A person may have one role
 - An owner is set as owner within the GitHub organization
 - A member is added to GitHub organization
+- A member is added to private space in Matrix
 - New roles can be created in a specific service (Matrix, GitHub etc.) to
   workaround restrictions of that service
 - Any permission in a specific service (Matrix, GitHub etc.) is allowed to be

--- a/roles.md
+++ b/roles.md
@@ -13,7 +13,8 @@ collective.
 ## Rules to Follow
 
 - A person may have one role
-- An owner is set as owner within the GitHub organization
+- An owner should be set as owner within the GitHub organization
+- An owner should have access to `@admin:mouseless.org` account
 - A member is added to GitHub organization
 - A member is added to private space in Matrix
 - New roles can be created in a specific service (Matrix, GitHub etc.) to


### PR DESCRIPTION
Redirect scripts to use matrix sdk with using matrix admin account in
`mouseless.org` and switch from discord messages to matrix messages in worklog
and reporting actions in work and workreport repos.

## Tasks

- [x] test matrix node client locally
- [x] replace matrix client with discord in workreport
- [x] add github bridge to bind github repos to matrix rooms as in discord

## Additional Tasks

- [x] add gcbrains bot to gcbrains server as well to report weekly in gcbrains
  matrix space
  - [x] github bridge in gcbrains
  - [x] report bot in accounting (keep slack code, add matrix as a config
    section like `slack`)
- [x] revise team structures to remove specific team names, instead document
  forming, naming and rules for teams
- [x] remove legal team from github system leaving only developers there
- [x] remove team and legal status from workreport
- [x] remove legal team from workreport and accounting
